### PR TITLE
Implements report URL

### DIFF
--- a/anteater/src/get_lists.py
+++ b/anteater/src/get_lists.py
@@ -292,3 +292,28 @@ class GetLists(object):
         except KeyError:
             logger.error('Key Error processing file_ignore list values')
         return file_ignore
+
+    def report_url(self, project):
+        project_report_url = False
+        report_url = False
+        try:
+            project_exceptions = il.get('project_exceptions')
+            for item in project_exceptions:
+                if project in item:
+                    exception_file = item.get(project)
+                    with open(exception_file, 'r') as f:
+                        report_list = yaml.safe_load(f)
+                        project_report_url = report_list['report_url']
+        except KeyError:
+            logger.info('No ip_ignore for %s', project)
+
+        try:
+            report_url = il['report_url']
+        except KeyError:
+            logger.error('Key Error processing ip_ignore list values')
+
+        if project_report_url:
+            return project_report_url
+        elif report_url:
+            return report_url
+

--- a/anteater/src/get_lists.py
+++ b/anteater/src/get_lists.py
@@ -316,4 +316,3 @@ class GetLists(object):
             return project_report_url
         elif report_url:
             return report_url
-

--- a/anteater/src/patch_scan.py
+++ b/anteater/src/patch_scan.py
@@ -98,7 +98,7 @@ def prepare_patchset(project, patchset, binaries, ips, urls):
                    file_ignore, ignore_directories, url_ignore, ip_ignore, apikey)
 
     # Process final result
-    process_failure()
+    process_failure(project)
 
 
 def scan_patch(project, patch_file, binaries, ips, urls, file_audit_list,
@@ -327,10 +327,14 @@ def scan_url(url, apikey):
         pass
 
 
-def process_failure():
+def process_failure(project):
     """
     If any scan operations register a failure, sys.exit(1) is called
     to allow build to register a failure
     """
     if failure:
+        lists = get_lists.GetLists()
+        report_url = lists.report_url(project)
+        if report_url:
+            print(report_url)
         sys.exit(1)

--- a/anteater_files/ignore_list.yaml
+++ b/anteater_files/ignore_list.yaml
@@ -37,8 +37,12 @@ ip_ignore:
 ignore_directories:
   - .git/
 
-
 # Add your project exception file into here.
 project_exceptions:
   - testproject: anteater_files/testproject.yaml
   - functest: anteater_files/functest.yaml
+
+# Report URL that is displayed at the end of the job. If set in this file,
+# it will be global for all projects.
+# To set for an individual project, use the project_exception file
+report_url: 'http://anteater.readthedocs.io/en/latest'

--- a/anteater_files/testproject.yaml
+++ b/anteater_files/testproject.yaml
@@ -21,7 +21,7 @@ file_audits:
 
 ip_ignore:
   - '192.0.43.8'
-  
+
 url_ignore:
   - 'www.iana.org'
 
@@ -35,3 +35,5 @@ file_ignore:
 # delimiter, but don't start with one!
 ignore_directories:
   - .git/
+
+report_url: 'http://anteater.readthedocs.io/en/latest/'


### PR DESCRIPTION
If a `report_url` is set in ignore_list.yaml, it will display a
report URL at the end of the anteater job (if the job fails, e.g
if finds a string match, or positive VT API match).

Individual project report URLs can be set within the
project_exceptions file.

https://github.com/anteater/anteater/issues/38