### PR TITLE
Fix "use before define" issues so unspecified config keys are skipped; fix regexes; add missing globals; always ignore anteater_files

### DIFF
--- a/anteater/main.py
+++ b/anteater/main.py
@@ -33,7 +33,7 @@ from anteater import LOG
 from anteater.src.patch_scan import prepare_patchset
 from anteater.src.project_scan import prepare_project
 
-config = six.moves.configparser.SafeConfigParser()
+config = six.moves.configparser.ConfigParser()
 config.read('anteater.conf')
 reports_dir = config.get('config', 'reports_dir')
 __version__ = "0.22"

--- a/anteater/src/get_lists.py
+++ b/anteater/src/get_lists.py
@@ -23,7 +23,7 @@ import yaml
 import sys
 
 
-config = six.moves.configparser.SafeConfigParser()
+config = six.moves.configparser.ConfigParser()
 config.read('anteater.conf')
 logger = logging.getLogger(__name__)
 anteater_files = config.get('config', 'anteater_files')

--- a/anteater/src/get_lists.py
+++ b/anteater/src/get_lists.py
@@ -117,11 +117,11 @@ class GetLists(object):
     def binary_hash(self, project, patch_file):
         """ Gathers sha256 hashes from binary lists """
         global il
-        exception_file = None
         try:
             project_exceptions = il.get('project_exceptions')
         except KeyError:
             logger.info('project_exceptions missing in %s for %s', ignore_list, project)
+            project_exceptions = []
 
         for project_files in project_exceptions:
             if project in project_files:
@@ -151,17 +151,18 @@ class GetLists(object):
 
     def file_audit_list(self, project):
         """ Gathers file name lists """
-        project_list = False
         self.load_project_flag_list_file(il.get('project_exceptions'), project)
         try:
             default_list = set((fl['file_audits']['file_names']))
         except KeyError:
-            logger.error('Key Error processing file_names list values')
+            logger.warning('No file_names found')
+            default_list = set()
         try:
             project_list = set((fl['file_audits'][project]['file_names']))
             logger.info('Loaded %s specific file_audits entries', project)
         except KeyError:
             logger.info('No project specific file_names section for project %s', project)
+            project_list = set()
 
         file_names_re = re.compile("|".join(default_list),
                                    flags=re.IGNORECASE)
@@ -176,24 +177,25 @@ class GetLists(object):
 
     def file_content_list(self, project):
         """ gathers content strings """
-        project_list = False
         self.load_project_flag_list_file(il.get('project_exceptions'), project)
         try:
             flag_list = (fl['file_audits']['file_contents'])
         except KeyError:
-            logger.error('Key Error processing file_contents list values')
+            logger.warning('No file_contents found')
+            flag_list = {}
 
         try:
             ignore_list = il['file_audits']['file_contents']
         except KeyError:
-            logger.error('Key Error processing file_contents list values')
+            logger.warning('No file_contents ignore list found')
+            ignore_list = []
 
         try:
             project_list = fl['file_audits'][project]['file_contents']
             logger.info('Loaded %s specific file_contents entries', project)
-
         except KeyError:
             logger.info('No project specific file_contents section for project %s', project)
+            project_list = []
 
         if project_list:
             ignore_list_merge = project_list + ignore_list
@@ -208,11 +210,12 @@ class GetLists(object):
 
     def ignore_directories(self, project):
         """ Gathers a list of directories to ignore """
-        project_list = False
+        project_list = []
         try:
             ignore_directories = il['ignore_directories']
         except KeyError:
-            logger.error('Key Error processing ignore_directories list values')
+            logger.warning('No ignore_directories found')
+            ignore_directories = []
 
         try:
             project_exceptions = il.get('project_exceptions')
@@ -233,11 +236,12 @@ class GetLists(object):
 
     def url_ignore(self, project):
         """ Gathers a list of URLs to ignore """
-        project_list = False
+        project_list = []
         try:
             url_ignore = il['url_ignore']
         except KeyError:
-            logger.error('Key Error processing url_ignore list values')
+            logger.warning('No url_ignore found')
+            url_ignore = []
 
         try:
             project_exceptions = il.get('project_exceptions')
@@ -260,11 +264,12 @@ class GetLists(object):
 
     def ip_ignore(self, project):
         """ Gathers a list of URLs to ignore """
-        project_list = False
+        project_list = []
         try:
             ip_ignore = il['ip_ignore']
         except KeyError:
-            logger.error('Key Error processing ip_ignore list values')
+            logger.warning('No ip_ignore found')
+            ip_ignore = []
 
         try:
             project_exceptions = il.get('project_exceptions')
@@ -290,7 +295,8 @@ class GetLists(object):
         try:
             file_ignore = (il['file_ignore'])
         except KeyError:
-            logger.error('Key Error processing file_ignore list values')
+            logger.warning('No file_ignore found')
+            return {}
         return file_ignore
 
     def report_url(self, project):
@@ -305,12 +311,12 @@ class GetLists(object):
                         report_list = yaml.safe_load(f)
                         project_report_url = report_list['report_url']
         except KeyError:
-            logger.info('No ip_ignore for %s', project)
+            logger.info('No report_url for %s', project)
 
         try:
             report_url = il['report_url']
         except KeyError:
-            logger.error('Key Error processing ip_ignore list values')
+            logger.warning('No report_url found')
 
         if project_report_url:
             return project_report_url

--- a/anteater/src/get_lists.py
+++ b/anteater/src/get_lists.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 anteater_files = config.get('config', 'anteater_files')
 flag_list = config.get('config', 'flag_list')
 ignore_list = config.get('config', 'ignore_list')
-ignore_dirs = ['.git', 'examples', anteater_files]
+ignore_dirs = ['.git', anteater_files]
 
 try:
     with open(flag_list, 'r') as f:
@@ -230,9 +230,7 @@ class GetLists(object):
 
         if project_list:
             ignore_directories = ignore_directories + project_list
-            return ignore_directories
-        else:
-            return ignore_directories
+        return ignore_directories + ignore_dirs
 
     def url_ignore(self, project):
         """ Gathers a list of URLs to ignore """

--- a/anteater/src/patch_scan.py
+++ b/anteater/src/patch_scan.py
@@ -181,7 +181,7 @@ def scan_patch(project, patch_file, binaries, ips, urls, file_audit_list,
 
                         #  Check for URLs and send for report to Virus Total
                         if urls:
-                            url = re.search("(?P<url>https?://[^\s]+)", line) or re.search("(?P<url>www[^\s]+)", line)
+                            url = re.search(r"(?P<url>https?://\S+)", line) or re.search(r"(?P<url>www\S+)", line)
                             if url:
                                 url = url.group("url")
                                 if re.search(url_ignore, url):

--- a/anteater/src/patch_scan.py
+++ b/anteater/src/patch_scan.py
@@ -35,7 +35,6 @@ config = six.moves.configparser.ConfigParser()
 config.read('anteater.conf')
 anteater_files = config.get('config', 'anteater_files')
 reports_dir = config.get('config', 'reports_dir')
-hasher = hashlib.sha256()
 failure = False
 
 

--- a/anteater/src/patch_scan.py
+++ b/anteater/src/patch_scan.py
@@ -33,7 +33,6 @@ from . import virus_total
 logger = logging.getLogger(__name__)
 config = six.moves.configparser.ConfigParser()
 config.read('anteater.conf')
-anteater_files = config.get('config', 'anteater_files')
 reports_dir = config.get('config', 'reports_dir')
 failure = False
 

--- a/anteater/src/patch_scan.py
+++ b/anteater/src/patch_scan.py
@@ -162,6 +162,7 @@ def scan_patch(project, patch_file, binaries, ips, urls, file_audit_list,
                     file_exists = True
                 except IOError:
                     file_exists = False
+                    lines = []
 
                 if file_exists and not patch_file.endswith(tuple(file_ignore)):
                     for line in lines:
@@ -171,7 +172,7 @@ def scan_patch(project, patch_file, binaries, ips, urls, file_audit_list,
                             if ipaddr:
                                 ipaddr = ipaddr[0]
                                 if re.search(ip_ignore, ipaddr):
-                                        logger.info('%s is in IP ignore list.', ipaddr)
+                                    logger.info('%s is in IP ignore list.', ipaddr)
                                 else:
                                     try:
                                         ipaddress.ip_address(ipaddr).is_global
@@ -251,10 +252,10 @@ def negative_report(binary_report, sha256hash, project, patch_file):
     logger.info('The following sha256 hash can be used in your %s.yaml file to suppress this scan:', project)
     logger.info('%s', sha256hash)
     with open(reports_dir + "binaries-" + project + ".log", "a") as gate_report:
-                gate_report.write('Non Whitelisted Binary: {}\n'.format(patch_file))
-                gate_report.write('File scan date for {} shows a clean status on {}\n'.format(patch_file, scan_date))
-                gate_report.write('The following sha256 hash can be used in your {}.yaml file to suppress this scan:\n'.format(project))
-                gate_report.write('{}\n'.format(sha256hash))
+        gate_report.write('Non Whitelisted Binary: {}\n'.format(patch_file))
+        gate_report.write('File scan date for {} shows a clean status on {}\n'.format(patch_file, scan_date))
+        gate_report.write('The following sha256 hash can be used in your {}.yaml file to suppress this scan:\n'.format(project))
+        gate_report.write('{}\n'.format(sha256hash))
 
 
 def positive_report(binary_report, sha256hash, project, patch_file):
@@ -314,6 +315,7 @@ def scan_url(url, apikey):
     try:
         positives = url_report['positives']
         if positives > 0:
+            detected = False
             for site, results in url_report['scans'].items():
                 if results['detected']:
                     detected = True

--- a/anteater/src/patch_scan.py
+++ b/anteater/src/patch_scan.py
@@ -31,7 +31,7 @@ from . import get_lists
 from . import virus_total
 
 logger = logging.getLogger(__name__)
-config = six.moves.configparser.SafeConfigParser()
+config = six.moves.configparser.ConfigParser()
 config.read('anteater.conf')
 anteater_files = config.get('config', 'anteater_files')
 reports_dir = config.get('config', 'reports_dir')

--- a/anteater/src/patch_scan.py
+++ b/anteater/src/patch_scan.py
@@ -261,6 +261,7 @@ def positive_report(binary_report, sha256hash, project, patch_file):
     """
     If a Positive match is found
     """
+    global failure
     failure = True
     report_url = binary_report['permalink']
     scan_date = binary_report['scan_date']
@@ -273,6 +274,7 @@ def scan_ipaddr(ipaddr, apikey):
     """
     If an IP Address is found, scan it
     """
+    global failure
     logger.info('Query VirusTotal API for Public IP Found: %s', ipaddr)
     v_api = virus_total.VirusTotal()
     scan_ip = v_api.send_ip(ipaddr, apikey)
@@ -293,6 +295,7 @@ def scan_url(url, apikey):
     """
     If URL is found, scan it
     """
+    global failure
     logger.info('Found what I believe is a URL: %s', url)
     v_api = virus_total.VirusTotal()
     while True:

--- a/anteater/src/project_scan.py
+++ b/anteater/src/project_scan.py
@@ -19,7 +19,6 @@ from __future__ import division, print_function, absolute_import
 import ipaddress
 import logging
 import hashlib
-import json
 import six.moves.configparser
 import os
 import re
@@ -82,9 +81,11 @@ def prepare_project(project, project_dir, binaries, ips, urls):
             sys.exit(1)
 
     # Perform rudimentary scans
-    scan_file(project, project_dir, binaries, ips, urls, file_audit_list,
-              file_audit_project_list, flag_list, ignore_list, hashlist,
-              file_ignore, ignore_directories, url_ignore, ip_ignore, apikey)
+    issues_found = scan_file(project, project_dir, binaries, ips, urls, file_audit_list,
+                             file_audit_project_list, flag_list, ignore_list, hashlist,
+                             file_ignore, ignore_directories, url_ignore, ip_ignore, apikey)
+    if issues_found:
+        sys.exit(1)
 
 
 def scan_file(project, project_dir, binaries, ips, urls, file_audit_list,
@@ -94,6 +95,7 @@ def scan_file(project, project_dir, binaries, ips, urls, file_audit_list,
     Main scan tasks begin
     """
     logger.info("Commencing scan tasks..")
+    issues_found = False
     for root, dirs, files in os.walk(project_dir):
         # Filter out ignored directories from list.
         for items in files:
@@ -106,6 +108,7 @@ def scan_file(project, project_dir, binaries, ips, urls, file_audit_list,
                     match = file_audit_list.search(full_path)
                     logger.error('Blacklisted filename: %s', full_path)
                     logger.error('Matched String: %s', match.group())
+                    issues_found = True
                     with open(reports_dir + "file-names_" + project + ".log", "a") as gate_report:
                         gate_report.write('Blacklisted filename: {0}\n'.format(full_path))
                         gate_report.write('Matched String: {0}'.format(match.group()))
@@ -125,7 +128,8 @@ def scan_file(project, project_dir, binaries, ips, urls, file_audit_list,
                         logger.info('No further action needed for: %s', full_path)
                     else:
                         logger.info('Non Whitelisted Binary file: %s', full_path)
-                        scan_binary(full_path, split_path, project, sha256hash, apikey)
+                        binary_issues_found = scan_binary(full_path, split_path, project, sha256hash, apikey)
+                        issues_found = issues_found or binary_issues_found
 
                 else:
                     if not items.endswith(tuple(file_ignore)) and not is_binary(full_path):
@@ -150,7 +154,8 @@ def scan_file(project, project_dir, binaries, ips, urls, file_audit_list,
                                     else:
                                         try:
                                             ipaddress.ip_address(ipaddr).is_global
-                                            scan_ipaddr(ipaddr, line, project, split_path, apikey)
+                                            ipaddr_issues_found = scan_ipaddr(ipaddr, line, project, split_path, apikey)
+                                            issues_found = issues_found or ipaddr_issues_found
                                         except:
                                             pass  # Ok to pass here, as this captures the odd string which is nt an IP Address
 
@@ -162,7 +167,8 @@ def scan_file(project, project_dir, binaries, ips, urls, file_audit_list,
                                     if re.search(url_ignore, url):
                                         logger.info('%s is in URL ignore list.', url)
                                     else:
-                                        scan_url(url, line, project, split_path, apikey)
+                                        url_issues_found = scan_url(url, line, project, split_path, apikey)
+                                        issues_found = issues_found or url_issues_found
 
                             # Check flagged content in files
                             for key, value in flag_list.items():
@@ -173,11 +179,14 @@ def scan_file(project, project_dir, binaries, ips, urls, file_audit_list,
                                     logger.error('Flagged Content: %s', line.rstrip())
                                     logger.error('Matched Regular Exp: %s', regex)
                                     logger.error('Rationale: %s', desc.rstrip())
+                                    issues_found = True
                                     with open(reports_dir + "contents-" + project + ".log", "a") as gate_report:
                                         gate_report.write('File contains violation: {0}\n'.format(full_path))
                                         gate_report.write('Flagged Content: {0}'.format(line))
                                         gate_report.write('Matched Regular Exp: {0}'.format(regex))
                                         gate_report.write('Rationale: {0}\n'.format(desc.rstrip()))
+
+    return issues_found
 
 
 def scan_binary(full_path, split_path, project, sha256hash, apikey):
@@ -210,8 +219,10 @@ def scan_binary(full_path, split_path, project, sha256hash, apikey):
 
     if positives == 0:
         negative_report(binary_report, sha256hash, split_path, project, full_path)
+        return False
     else:
         positive_report(binary_report, sha256hash, split_path, project, full_path)
+        return True
 
 
 def negative_report(binary_report, sha256hash, split_path, project, full_path):
@@ -268,9 +279,11 @@ def scan_ipaddr(ipaddr, line, project, split_path, apikey):
                 logger.info('%s on date: %s', url['url'], url['scan_date'])
                 gate_report.write('{} on {}\n'.format(url['url'], url['scan_date']))
                 sleep(0.2)
+            return True
         else:
             logger.info('No malicious DNS history found for: %s', ipaddr)
             gate_report.write('No malicious DNS history found for: {}\n'.format(ipaddr))
+            return False
 
 
 def scan_url(url, line, project, split_path, apikey):
@@ -313,12 +326,14 @@ def scan_url(url, line, project, split_path, apikey):
                 with open(reports_dir + "urls-" + project + ".log", "a") as gate_report:
                     logger.error("Full report available here: %s", url_report['permalink'])
                     gate_report.write('Full report available here: {}\n'.format(url_report['permalink']))
+            return True
 
         else:
             logger.info("%s is recorded as a clean", url)
             with open(reports_dir + "urls-" + project + ".log", "a") as gate_report:
                 gate_report.write('{} is recorded as a clean\n'.format(url))
+            return False
 
     except:
         # No positives so we can pass this
-        pass
+        return False

--- a/anteater/src/project_scan.py
+++ b/anteater/src/project_scan.py
@@ -160,7 +160,7 @@ def scan_file(project, project_dir, binaries, ips, urls, file_audit_list,
 
                             # Check for URLs and send for report to Virus Total
                             if urls:
-                                url = re.search("(?P<url>https?://[^\s]+)", line) or re.search("(?P<url>www[^\s]+)", line)
+                                url = re.search(r"(?P<url>https?://\S+)", line) or re.search(r"(?P<url>www\S+)", line)
                                 if url:
                                     url = url.group("url")
                                     if re.search(url_ignore, url):

--- a/anteater/src/project_scan.py
+++ b/anteater/src/project_scan.py
@@ -35,7 +35,6 @@ config.read('anteater.conf')
 anteater_files = config.get('config', 'anteater_files')
 reports_dir = config.get('config', 'reports_dir')
 ignore_dirs = ['.git', 'examples', anteater_files]
-hasher = hashlib.sha256()
 
 
 def prepare_project(project, project_dir, binaries, ips, urls):

--- a/anteater/src/project_scan.py
+++ b/anteater/src/project_scan.py
@@ -66,6 +66,7 @@ def prepare_project(project, project_dir, binaries, ips, urls):
     # Get Binary Ignore Lists
     hashlist = get_lists.GetLists()
 
+    apikey = ""
     if binaries or ips or urls:
         try:
             apikey = os.environ["VT_KEY"]
@@ -141,6 +142,7 @@ def scan_file(project, project_dir, binaries, ips, urls, file_audit_list,
                             lines = fo.readlines()
                         except IOError:
                             logger.error('%s does not exist', full_path)
+                            lines = []
 
                         for line in lines:
                             # Find IP Addresses and send for report to Virus Total
@@ -228,10 +230,10 @@ def negative_report(binary_report, sha256hash, split_path, project, full_path):
     logger.info('The following sha256 hash can be used in your %s.yaml file to suppress this scan:', project)
     logger.info('%s:', sha256hash)
     with open(reports_dir + "binaries-" + project + ".log", "a") as gate_report:
-                gate_report.write('Non Whitelisted Binary: {}\n'.format(full_path))
-                gate_report.write('File scan date for {} shows a clean status on {}\n'.format(split_path, scan_date))
-                gate_report.write('The following sha256 hash can be used in your {}.yaml file to suppress this scan:\n'.format(project))
-                gate_report.write('{}\n'.format(sha256hash))
+        gate_report.write('Non Whitelisted Binary: {}\n'.format(full_path))
+        gate_report.write('File scan date for {} shows a clean status on {}\n'.format(split_path, scan_date))
+        gate_report.write('The following sha256 hash can be used in your {}.yaml file to suppress this scan:\n'.format(project))
+        gate_report.write('{}\n'.format(sha256hash))
 
 
 def positive_report(binary_report, sha256hash, split_path, project, full_path):
@@ -244,9 +246,9 @@ def positive_report(binary_report, sha256hash, split_path, project, full_path):
     logger.info('File scan date for %s shows a infected status on: %s', split_path, scan_date)
     logger.info('Full report available here: %s', report_url)
     with open(reports_dir + "binaries-" + project + ".log", "a") as gate_report:
-                gate_report.write('Virus Found!: {}\n'.format(full_path))
-                gate_report.write('File scan date for {} shows a infected status on: {}\n'.format(split_path, scan_date))
-                gate_report.write('Full report avaliable here: {}\n'.format(report_url))
+        gate_report.write('Virus Found!: {}\n'.format(full_path))
+        gate_report.write('File scan date for {} shows a infected status on: {}\n'.format(split_path, scan_date))
+        gate_report.write('Full report avaliable here: {}\n'.format(report_url))
 
 
 def scan_ipaddr(ipaddr, line, project, split_path, apikey):

--- a/anteater/src/project_scan.py
+++ b/anteater/src/project_scan.py
@@ -32,9 +32,7 @@ from . import virus_total
 logger = logging.getLogger(__name__)
 config = six.moves.configparser.ConfigParser()
 config.read('anteater.conf')
-anteater_files = config.get('config', 'anteater_files')
 reports_dir = config.get('config', 'reports_dir')
-ignore_dirs = ['.git', 'examples', anteater_files]
 
 
 def prepare_project(project, project_dir, binaries, ips, urls):

--- a/anteater/src/project_scan.py
+++ b/anteater/src/project_scan.py
@@ -108,14 +108,9 @@ def scan_file(project, project_dir, binaries, ips, urls, file_audit_list,
                     match = file_audit_list.search(full_path)
                     logger.error('Blacklisted filename: %s', full_path)
                     logger.error('Matched String: %s', match.group())
-                    with open(reports_dir + "file-names_" + project + ".log",
-                              "a") as gate_report:
-                                gate_report. \
-                                    write('Blacklisted filename: {0}\n'.
-                                          format(full_path))
-                                gate_report. \
-                                    write('Matched String: {0}'.
-                                          format(match.group()))
+                    with open(reports_dir + "file-names_" + project + ".log", "a") as gate_report:
+                        gate_report.write('Blacklisted filename: {0}\n'.format(full_path))
+                        gate_report.write('Matched String: {0}'.format(match.group()))
 
                 # Check if Binary is whitelisted
                 if is_binary(full_path) and binaries:

--- a/anteater/src/project_scan.py
+++ b/anteater/src/project_scan.py
@@ -135,6 +135,9 @@ def scan_file(project, project_dir, binaries, ips, urls, file_audit_list,
                         except IOError:
                             logger.error('%s does not exist', full_path)
                             lines = []
+                        except UnicodeDecodeError:
+                            logger.error('%s is not valid utf-8', full_path)
+                            lines = []
 
                         for line in lines:
                             # Find IP Addresses and send for report to Virus Total

--- a/anteater/src/project_scan.py
+++ b/anteater/src/project_scan.py
@@ -30,7 +30,7 @@ from . import get_lists
 from . import virus_total
 
 logger = logging.getLogger(__name__)
-config = six.moves.configparser.SafeConfigParser()
+config = six.moves.configparser.ConfigParser()
 config.read('anteater.conf')
 anteater_files = config.get('config', 'anteater_files')
 reports_dir = config.get('config', 'reports_dir')

--- a/anteater/src/virus_total.py
+++ b/anteater/src/virus_total.py
@@ -110,7 +110,7 @@ class VirusTotal():
             if response.status_code == self.HTTP_OK:
                 self.logger.info("sent: %s, HTTP: %d, content: %s", os.path.basename(filename), response.status_code, response.text)
             elif response.status_code == self.HTTP_RATE_EXCEEDED:
-                    time.sleep(20)
+                time.sleep(20)
             else:
                 self.logger.error("sent: %s, HTTP: %d", os.path.basename(filename), response.status_code)
             return response
@@ -148,7 +148,7 @@ class VirusTotal():
                 json_response = response.json()
                 return json_response
             elif response.status_code == self.HTTP_RATE_EXCEEDED:
-                    time.sleep(20)
+                time.sleep(20)
             else:
                 self.logger.error("sent: %s, HTTP: %d", ipaddr, response.status_code)
             time.sleep(self.public_api_sleep_time)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-anteater==0.15
 appdirs==1.4.3
 binaryornot==0.4.4
 certifi==2018.1.18

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36
+envlist = py38
 
 [testenv]
 commands =


### PR DESCRIPTION
Successfully tested on a local repo with minimal config files:

* ignore_list.yaml
```
project_exceptions:
  nullvalue

file_audits:
  file_contents:
    - "somevalue"
```
* file_list.yaml
```
file_audits:
  file_names:
    - \.asc
  file_contents:
    password:
        regex: password
        desc: "Hardcoding passwords is baad!"
```